### PR TITLE
add repository hook

### DIFF
--- a/hooks/post-rewrite
+++ b/hooks/post-rewrite
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+# All of this would be easier if the git command itself could add the obsoletes
+# trailers when it rewrites the commits.
+
+echo Running the post-rewrite hook
+
+# From githooks(5): first argument denotes the command it was invoked by:
+# currently one of amend or rebase. Ignore it for now.
+invoked_by=$1; shift
+
+# The hook receives a list of the rewritten commits on stdin, in the format
+#
+#     <old-sha1> SP <new-sha1> [ SP <extra-info> ] LF
+#
+# Write it to a temporary file we can read repeatedly
+rewrites_file=$(mktemp -t post-rewrite.XXXXXX)
+trap "rm -f ${rewrites_file}" EXIT
+cat > ${rewrites_file}
+
+# When you `git-rebase --interactive` and then use the procedure for SPLITTING
+# COMMITS described in the help, it leaves holes in the list of rewrites for
+# the new commits except for the last one, which is paired with the
+# original commit. For the purposes of git obsolescence, this fills in the
+# holes. When splitting out a commit, each new commit should point to the
+# original commit as its predecessor.
+
+# The following works back through the log of new commits starting from the new
+# HEAD. This is the reverse order as the rewrites are fed into stdin. So, we
+# need to be careful to work through the file in reverse. Hence the use of tac.
+oldhead=$(awk 'END{print$1}' ${rewrites_file})
+newhead=$(awk 'END{print$2}' ${rewrites_file})
+for new_sha in $(git log --topo-order --pretty=%H ${oldhead}..${newhead})
+do
+    old_shas=$(awk -v sha=${new_sha} '$2 == sha {print$1}' ${rewrites_file} | tac)
+    if [ -z "$old_shas" ]
+    then
+        # This fills in the hole with the last known original commit
+        echo $last $new_sha
+        continue
+    fi
+    for old_sha in ${old_shas}
+    do
+        echo $old_sha $new_sha
+    done
+    last=$old_sha
+done | tac > ${rewrites_file}.new
+
+# Use the new file with the holes filled in.
+mv ${rewrites_file}.new ${rewrites_file}
+
+# Iterate over the new shas (2nd field). The commits are guaranteed to be
+# listed in the order that they were processed by rebase.
+new_shas=$(cut -d ' ' -f 2 ${rewrites_file} | uniq)
+
+# Note, this commit hook doesn't work for preserved merge commits. It assumes
+# each rewritten commit has a single parent. Handling merge commits would
+# require an algorithm sensitive to the DAG nature of commit graphs.
+base="$(awk '{print$2;exit}' ${rewrites_file})^"
+parents=()
+if git rev-parse --quiet --verify ${base} >/dev/null
+then
+    parents=(-p $(git rev-parse ${base}))
+fi
+
+for new_sha in ${new_shas}
+do
+    old_shas=$(awk -v sha=${new_sha} '$2 == sha {print$1}' ${rewrites_file})
+    trailers=()
+    for old_sha in ${old_shas}
+    do
+        trailers+=(--trailer obsoletes:${old_sha})
+    done
+
+    export GIT_AUTHOR_NAME=$(git log -1 --pretty=%an ${new_sha})
+    export GIT_AUTHOR_EMAIL=$(git log -1 --pretty=%ae ${new_sha})
+    export GIT_AUTHOR_DATE=$(git log -1 --pretty=%aD ${new_sha})
+    export GIT_COMMITTER_NAME=$(git log -1 --pretty=%cn ${new_sha})
+    export GIT_COMMITTER_EMAIL=$(git log -1 --pretty=%ce ${new_sha})
+
+    tree=$(git log -1 --pretty=%T ${new_sha})
+
+    parent=$(git log -1 --pretty=%B ${new_sha} |
+        grep -v "^obsoletes: " |
+        git interpret-trailers "${trailers[@]}" |
+        git commit-tree ${tree} "${parents[@]}")
+    parents=(-p $parent)
+
+    echo "${parent} obsoletes the following commits"
+    for old_sha in ${old_shas}
+    do
+        echo "    -> ${old_sha}"
+    done
+done
+
+echo Finished running the post-rewrite hook
+
+# Finally, reset the current branch to the new chain of commits
+git reset ${parent}

--- a/shell
+++ b/shell
@@ -36,6 +36,25 @@ fi
 mydir=$(cd $(dirname "$0") && pwd)
 export PATH=${mydir}/bin:$PATH
 
+hookdir=$(git rev-parse --git-dir)/hooks
+if [ -L "${hookdir}/post-rewrite" ]
+then
+    echo >&2 "Refusing to run the git obsolescence wrapper within itself"
+    exit 1
+fi
+
+if [ -f "${hookdir}/post-rewrite" ]
+then
+    echo >&2 "Repository already has a post-rewrite hook"
+    exit 1
+fi
+ln -sf ${mydir}/hooks/post-rewrite ${hookdir}/post-rewrite
+
+cleanup() {
+    rm -f ${hookdir}/post-rewrite
+}
+trap cleanup EXIT
+
 # If no arguments were given, start an interactive shell
 if [ $# -eq 0 ]
 then
@@ -51,4 +70,4 @@ then
     set -- $SHELL
 fi
 
-exec ${1+"$@"}
+${1+"$@"}

--- a/test/common.sh
+++ b/test/common.sh
@@ -1,0 +1,100 @@
+projectdir=$(cd $(dirname "$0")/.. && pwd)
+
+# Common test initialization. Create a new git workspace and set it up
+if [ -z "$TEST_TMP_DIR" ]
+then
+    # If you're on a mac, please install GNU coreutils. Sorry, no time to fight
+    # with mktemp incompatibilities.
+    if [ -d "/usr/local/opt/coreutils/libexec/gnubin" ]
+    then
+        export PATH=/usr/local/opt/coreutils/libexec/gnubin:$PATH
+    fi
+
+    export TEST_TMP_DIR=$(mktemp -d -t obsolescence.XXXXXX)
+    export TMPDIR=${TEST_TMP_DIR}
+
+    mkdir -p $TEST_TMP_DIR/workspace
+    pushd $TEST_TMP_DIR/workspace
+    git init
+    rm -rf $(git rev-parse --git-dir )/hooks/*.sample
+
+    script=$projectdir/test/$(basename "$0")
+    # Re-exec the test script given the new repository setup
+    exec $projectdir/shell $script ${1+"$@"}
+else
+    cleanup() {
+        rm -rf $TEST_TMP_DIR
+    }
+    trap cleanup EXIT
+fi
+
+export GIT_AUTHOR_NAME="Test Author"
+export GIT_AUTHOR_EMAIL="author@example.com"
+export GIT_COMMITTER_NAME="Test Committer"
+export GIT_COMMITTER_EMAIL="committer@example.com"
+
+quick_commit_files() {
+    local msg=$1
+
+    for filename in ${1+"$@"}
+    do
+        touch $filename
+        git add $filename
+    done
+    git commit -m "$msg"
+}
+
+list_predecessors() {
+    local commit=$1
+    git log -1 --pretty=%B $commit |
+        git interpret-trailers --parse |
+        awk '$1=="obsoletes:"{print$2}'
+}
+
+troubleshoot() {
+    if [ -t 0 ]
+    then
+        echo >&2 "You're now in a troubleshooting shell, exit the shell to get back"
+        $SHELL
+    fi
+}
+
+fail() {
+    echo ${1+"$@"}
+    troubleshoot
+    exit 1
+}
+
+assert_revs_equal() {
+    local name=$1
+    local expected=$2
+    local actual=$3
+    if [ "$(git rev-parse ${expected})" != "$(git rev-parse ${actual})" ]
+    then
+        fail "$name expected to be $expected but was $actual"
+    fi
+}
+
+# ed_it makes it convenient to use `git rebase --interactive` non-interactively
+# by supplying `ed` commands on stdin to edit the commit list. It writes the
+# commands as a bash script to a temporary file and sets that script as EDITOR.
+# This isn't perfect. For example, you can't use squash or anything that
+# invokes an editor during the interactive rebase.
+ed_it() {
+    local script=$(mktemp -t ed.XXXXXX)
+    cat >${script} <<-SCRIPT
+	#!/bin/bash
+	
+	ed -s \$1 <<ED
+	$(cat)
+	ED
+	SCRIPT
+    chmod +x ${script}
+    EDITOR=${script} ${1+"$@"}
+}
+
+# no_edit makes it convenient to use `git rebase --interactive`
+# non-interactively to accept the default commit list without editing.
+no_edit() {
+    EDITOR=touch ${1+"$@"}
+}

--- a/test/test0001-rewriting-commits
+++ b/test/test0001-rewriting-commits
@@ -1,0 +1,102 @@
+#!/bin/bash -ex
+
+. "$(dirname "$0")/common.sh"
+
+########################################################################
+# Test amending the top commit
+#
+# Amends the HEAD commit and tests that the obsolescence graph is added.
+#
+########################################################################
+
+quick_commit_files "First commit" one
+quick_commit_files "Second commit" two
+
+oldhead=$(git rev-parse HEAD)
+
+echo stuff > two
+git add two
+
+git commit --amend --no-edit
+
+assert_revs_equal "predecessor reference" ${oldhead} $(list_predecessors HEAD)
+
+########################################################################
+# Test a fixup to an earlier commit
+#
+# Applies a fixup to an early commit and tests that the new commit points to
+# both predecessors
+#
+########################################################################
+
+echo text > one
+git commit -a --fixup $(git rev-parse HEAD)~
+
+old_head=$(git rev-parse HEAD)
+
+no_edit git rebase --root --autosquash --interactive
+
+assert_revs_equal "2nd commit predecessor"   ${old_head}~  $(list_predecessors HEAD)
+assert_revs_equal "1st commit predecessor 1" ${old_head}~2 $(list_predecessors HEAD~ | sed -n 1p)
+assert_revs_equal "1st commit predecessor 2" ${old_head}   $(list_predecessors HEAD~ | sed -n 2p)
+
+########################################################################
+# Test squashing commits
+#
+# Creates three commits and then squashes them together
+#
+########################################################################
+
+echo "squash"  > one
+git commit -a -m "squashme one"
+echo "squash" > two
+git commit -a -m "squashme two"
+
+quick_commit_files "squash three" three
+
+old_head=$(git rev-parse HEAD)
+
+ed_it git rebase --autosquash --interactive ${old_head}~3 <<ED
+2,3s/^pick/fixup/
+w
+ED
+
+# The first predecessor should be the earliest commit (by DAG, not necessarily
+# by date). This way, the new folded change takes on its change id. This is
+# consistent with the following from git-rebase(1) about fixups.
+#
+#     If the commits had different authors, the folded commit will be
+#     attributed to the author of the first commit. The suggested commit
+#     message ... omits the commit messages of commits with the "fixup"
+#     command.
+assert_revs_equal "predecessor 1" ${old_head}~2 $(list_predecessors HEAD | sed -n 1p)
+assert_revs_equal "predecessor 2" ${old_head}~1 $(list_predecessors HEAD | sed -n 2p)
+assert_revs_equal "predecessor 3" ${old_head}   $(list_predecessors HEAD | sed -n 3p)
+
+########################################################################
+# Test splitting a commit
+#
+# This uses the SPLITTING COMMITS procedure in git-rebase(1) to split an
+# original commit into two. Both new commits should point to the original
+# as its predecessor.
+#
+########################################################################
+
+echo splitme >one
+echo splitme >two
+quick_commit_files "split me" one two
+
+old_head=$(git rev-parse HEAD)
+
+ed_it git rebase --interactive ${old_head}~ <<ED
+1,s/^pick/edit/
+w
+ED
+
+git reset HEAD~
+quick_commit_files "split me one" one
+quick_commit_files "split me two" two
+git rebase --continue
+
+assert_revs_equal "commit 1 predecessor" ${old_head} $(list_predecessors HEAD~)
+assert_revs_equal "commit 2 predecessor" ${old_head} $(list_predecessors HEAD)


### PR DESCRIPTION
The post-rewrite repository hook is used to write the obsolescence graph for changes.